### PR TITLE
Adds new book form with validation & cover preview

### DIFF
--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -1,7 +1,197 @@
-import React from 'react'
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import { Label } from "@/components/ui/label";
+import { title } from "process";
+import { CreateBook, GetGenres } from "../api/data";
+const DEFAULT_COVER = "/covers/default-cover.png";
+const schema = z.object({
+  title: z.string().min(1),
+  author: z.string().min(1),
+  genre: z.string().min(1),
+  year_published: z.number().min(0),
+  pages: z.number().min(1),
+  synopsis: z.string().optional(),
+  status: z
+    .enum(["LIDO", "LENDO", "QUERO_LER", "PAUSADO", "ABANDONADO"])
+    .default("QUERO_LER"),
+  cover: z.string().url().or(z.literal("")).optional(),
+});
 
 export default function AddBookPage() {
+  const router = useRouter();
+  const [genres, setGenres] = useState<{ id: string; genre: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [coverPreview, setCoverPreview] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(schema),
+    defaultValues: { status: "QUERO_LER" },
+  });
+
+  const coverUrl = watch("cover");
+
+  useEffect(() => {
+    if (coverUrl && coverUrl.trim() !== "") {
+      setCoverPreview(coverUrl);
+    } else {
+      setCoverPreview(DEFAULT_COVER);
+    }
+  }, [coverUrl]);
+
+  useEffect(() => {
+    GetGenres().then(setGenres);
+  }, []);
+
+  const onSubmit = async (data: any) => {
+    setLoading(true);
+    try {
+      const yearNow = new Date().getFullYear();
+      await CreateBook({ ...data, year_registration: yearNow });
+      router.push("/library");
+    } catch {
+      alert("Erro ao criar livro");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>AddBook</div>
-  )
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Adicionar Novo Livro</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <div>
+          <Label className="block mb-1 font-semibold">Título</Label>
+          <Input {...register("title")} />
+          {errors.title && (
+            <p className="text-red-500">{errors.title.message}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Autor</Label>
+          <Input {...register("author")} />
+          {errors.author && (
+            <p className="text-red-500">{errors.author.message}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Gênero</Label>
+          <Select onValueChange={(value) => setValue("genre", value)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione o gênero" />
+            </SelectTrigger>
+            <SelectContent>
+              {genres.map((g) => (
+                <SelectItem key={g.id} value={g.genre}>
+                  {g.genre}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.genre && (
+            <p className="text-red-500">{errors.genre.message}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Ano de Publicação</Label>
+          <Input
+            type="number"
+            {...register("year_published", { valueAsNumber: true })}
+          />
+          {errors.year_published && (
+            <p className="text-red-500">{errors.year_published.message}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Número de Páginas</Label>
+          <Input
+            type="number"
+            {...register("pages", { valueAsNumber: true })}
+          />
+          {errors.pages && (
+            <p className="text-red-500">{errors.pages.message}</p>
+          )}
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Sinopse</Label>
+          <Textarea {...register("synopsis")} />
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">Status</Label>
+          <Select
+            onValueChange={(value) =>
+              setValue(
+                "status",
+                value as
+                  | "QUERO_LER"
+                  | "LIDO"
+                  | "LENDO"
+                  | "PAUSADO"
+                  | "ABANDONADO"
+              )
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione o status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="LENDO">Lendo</SelectItem>
+              <SelectItem value="LIDO">Lido</SelectItem>
+              <SelectItem value="QUERO_LER">Quero ler</SelectItem>
+              <SelectItem value="PAUSADO">Pausado</SelectItem>
+              <SelectItem value="ABANDONADO">Abandonado</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label className="block mb-1 font-semibold">URL da Capa</Label>
+          <Input type="text" {...register("cover")} placeholder="https://..." />
+        </div>
+
+        {coverPreview && (
+          <div className="mt-2">
+            <p className="mb-1 font-semibold">Preview da Capa:</p>
+            <img
+              src={coverPreview}
+              alt={`Capa do livro ${title}`}
+              className="object-cover w-[250px] h-[350px]"
+            />
+          </div>
+        )}
+
+        <Button type="submit" disabled={loading}>
+          {loading ? "Salvando..." : "Adicionar Livro"}
+        </Button>
+      </form>
+    </div>
+  );
 }

--- a/app/data/booksMock.json
+++ b/app/data/booksMock.json
@@ -64,6 +64,54 @@
       "status": "QUERO_LER",
       "synopsis": "Um grupo de amigos decide acampar em uma floresta isolada, mas descobre que o silêncio esconde segredos aterrorizantes.",
       "cover": ""
+    },
+    {
+      "id": "327c",
+      "title": "Icha Icha Paraíso",
+      "author": "Jiraya",
+      "genre": "Romance",
+      "year_published": 2011,
+      "pages": 630,
+      "synopsis": "O Icha Icha Paraíso (イチャイチャパラダイス, Icha Icha Paradaisu; Panini: \"Icha Icha Paradise\", \"Icha-Icha Paradise\" ou \"Jardim dos Amassos\"; Crunchyroll: \"Jardim dos Amassos\" ou \"Paraíso Icha Icha\")[10][11] ou Icha Para (イチャパラ; Panini: \"Icha-Para\")[12] foi o primeiro livro a aparecer na série, e também foi o primeiro a ser publicado. A capa é laranja e a ilustração mostra um homem alegre perseguindo uma mulher alegre. Seu enredo é resumido como: \"O personagem principal e a heroína, ambos novos no amor, começam a namorar e seus olhos gradualmente se abrem para o amor adulto\".",
+      "status": "QUERO_LER",
+      "cover": "https://m.media-amazon.com/images/I/51f-wC8p93L._UF1000,1000_QL80_.jpg",
+      "year_registration": 2025
+    },
+    {
+      "id": "dab3",
+      "title": "O Senhor dos Anéis",
+      "author": "J. R. R. Tolkien",
+      "genre": "Fantasia",
+      "year_published": 1949,
+      "pages": 1232,
+      "synopsis": "O Senhor dos Anéis é um livro de alta fantasia, escrito pelo escritor britânico J. R. R. Tolkien. Escrita entre 1937 e 1949, com muitas partes criadas durante a Segunda Guerra Mundial, a saga é uma continuação de O Hobbit.",
+      "status": "LENDO",
+      "cover": "https://m.media-amazon.com/images/I/71ZLavBjpRL._UF1000,1000_QL80_.jpg",
+      "year_registration": 2025
+    },
+    {
+      "id": "e077",
+      "title": "Teste",
+      "author": "teste",
+      "genre": "Ficção",
+      "year_published": 1202,
+      "pages": 1200,
+      "synopsis": "",
+      "status": "LENDO",
+      "cover": "https://wallpapers.com/images/hd/naruto-shippuden-pictures-th3sh08uchw11qg6.jpg",
+      "year_registration": 2025
+    },
+    {
+      "id": "d12e",
+      "title": "Teste",
+      "author": "Teste",
+      "genre": "Ficção",
+      "year_published": 1200,
+      "pages": 1022,
+      "synopsis": "fdsfsfasdfsfds ",
+      "status": "LIDO",
+      "cover": "",
+      "year_registration": 2025
     }
   ],
   "genres": [

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -6,12 +6,12 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@radix-ui/react-select";
+} from "@/components/ui/select";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { BooksItem } from "../_components/BooksItem";
 import { GetBooks, GetGenres } from "../api/data";
 import { Book } from "../types/books";
-import { useEffect, useState } from "react";
 
 export default function BooksList() {
   const [books, setBooks] = useState<Book[]>([]);
@@ -42,35 +42,43 @@ export default function BooksList() {
     const matchesGenre =
       selectedGenre === "all" || book.genre === selectedGenre;
 
-  return matchesSearch && matchesGenre;
-});
-  
+    return matchesSearch && matchesGenre;
+  });
+
   return (
     <div className="flex flex-col justify-center sm:justify-start gap-6">
       <h2 className="text-2xl font-bold m-3 text-center text-gray-700">
         Sua Biblioteca
       </h2>
+
       <div className="flex p-4 gap-3">
         <Input
           className="border border-gray-700"
-          placeholder="Filtrar por autor ou titulo..."
+          placeholder="Filtrar por autor ou título..."
           value={value}
           onChange={(e) => setValue(e.target.value)}
         />
-        <Select value={selectedGenre} onValueChange={setSelectedGenre}>
+        <Select
+          value={selectedGenre}
+          onValueChange={(val) => setSelectedGenre(val)}
+        >
           <SelectTrigger className="w-[180px] text-gray-950">
             <SelectValue placeholder="Filtrar por gênero" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos</SelectItem>
+            <SelectItem value="all">Todos os gêneros</SelectItem>
             {genres.map((genre) => (
-              <SelectItem key={genre.id} value={genre.genre}>
+              <SelectItem
+                key={genre.id}
+                value={genre.genre || String(genre.id)}
+              >
                 {genre.genre}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
+
       <div className="mt-8 flex flex-wrap items-center justify-center gap-6">
         {filteredBooks.length > 0 ? (
           filteredBooks.map((book) => (
@@ -85,7 +93,7 @@ export default function BooksList() {
             </Link>
           ))
         ) : (
-          <p className="text-gray-500">Nenhum livro cadastrado.</p>
+          <p className="text-gray-500">Nenhum livro encontrado.</p>
         )}
       </div>
     </div>

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { Input } from "@/components/ui/input";
 import {
   Select,

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -9,10 +9,41 @@ import {
 import Link from "next/link";
 import { BooksItem } from "../_components/BooksItem";
 import { GetBooks, GetGenres } from "../api/data";
+import { Book } from "../types/books";
+import { useEffect, useState } from "react";
 
-export default async function BooksList() {
-  const books = await GetBooks();
-  const genres = await GetGenres();
+export default function BooksList() {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [genres, setGenres] = useState<{ id: number; genre: string }[]>([]);
+  const [value, setValue] = useState("");
+  const [selectedGenre, setSelectedGenre] = useState("all");
+
+  useEffect(() => {
+    async function fetchData() {
+      const booksData = await GetBooks();
+      const genresData = await GetGenres();
+      setBooks(booksData);
+      setGenres(
+        genresData.map((genre: any) => ({
+          id: Number(genre.id),
+          genre: genre.genre || `Genero-${genre.id}`,
+        }))
+      );
+    }
+    fetchData();
+  }, []);
+
+  const filteredBooks = books.filter((book) => {
+    const matchesSearch =
+      book.title.toLowerCase().includes(value.toLowerCase()) ||
+      book.author.toLowerCase().includes(value.toLowerCase());
+
+    const matchesGenre =
+      selectedGenre === "all" || book.genre === selectedGenre;
+
+  return matchesSearch && matchesGenre;
+});
+  
   return (
     <div className="flex flex-col justify-center sm:justify-start gap-6">
       <h2 className="text-2xl font-bold m-3 text-center text-gray-700">
@@ -22,12 +53,15 @@ export default async function BooksList() {
         <Input
           className="border border-gray-700"
           placeholder="Filtrar por autor ou titulo..."
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
         />
-        <Select>
+        <Select value={selectedGenre} onValueChange={setSelectedGenre}>
           <SelectTrigger className="w-[180px] text-gray-950">
             <SelectValue placeholder="Filtrar por gênero" />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="all">Todos</SelectItem>
             {genres.map((genre) => (
               <SelectItem key={genre.id} value={genre.genre}>
                 {genre.genre}
@@ -37,8 +71,8 @@ export default async function BooksList() {
         </Select>
       </div>
       <div className="mt-8 flex flex-wrap items-center justify-center gap-6">
-        {books.length > 0 ? (
-          books.map((book) => (
+        {filteredBooks.length > 0 ? (
+          filteredBooks.map((book) => (
             <Link key={book.id} href={`/book/${book.id}`}>
               <BooksItem
                 title={book.title}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "",
+        hostname: "**",
         port: "",
         pathname: "/**",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,12 @@
         "json-server": "^1.0.0-beta.3",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
         "recharts": "^2.15.4",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^3.1.1",
         "zod": "^4.1.9"
@@ -6580,6 +6582,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7794,6 +7806,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/sort-on": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "json-server": "^1.0.0-beta.3",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
     "recharts": "^2.15.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1",
     "zod": "^4.1.9"


### PR DESCRIPTION
Implements a client-side flow to create books, with schema-based validation, genre selection, default status, and live cover URL preview (with a fallback image). On submit, records the current registration year and redirects to the library.

Adds reusable textarea and toast components and installs theme/toast dependencies to improve UX and future feedback handling.

Allows remote images from any host to support external book covers.

Expands mock dataset and performs minor cleanup in the library view.